### PR TITLE
Update maven dependency to correct version.

### DIFF
--- a/lang_java.adoc
+++ b/lang_java.adoc
@@ -41,7 +41,7 @@ following to one's `pom.xml`:
 <dependency>
     <groupId>io.kaitai</groupId>
     <artifactId>kaitai-struct-runtime</artifactId>
-    <version>0.7</version>
+    <version>0.8</version>
 </dependency>
 ----
 
@@ -110,7 +110,7 @@ public class Parent extends KaitaiStruct {
         public static class GrandChild extends KaitaiStruct {
         }
     }
-}    
+}
 ----
 
 Every generated class will have 3 constructors and a static factory


### PR DESCRIPTION
I was trying to adopt this tool in a Java project, and some classes in
the code generated by `ksc` were not found. I eventually thought to go
to Maven Central and, sure enough, found that there was a newer
release than the one the documentation told me to use.

You might want to consider using a tool like Maven Badges,
https://github.com/softwaremill/maven-badges so that your
documentation file is rendered with an image that shows the actual
latest release version, and which when clicked takes you to a page
showing how to add it as a dependency using many popular JVM-hosted
build tools. I do this on my own project pages, for example:
https://github.com/Deep-Symmetry/beat-link#installing