### PR TITLE
Add more methods: to_i of floating point number and min, max of array

### DIFF
--- a/user_guide.adoc
+++ b/user_guide.adoc
@@ -2484,6 +2484,14 @@ a few pre-defined internal methods (they all start with an underscore
 |`size`
 |Integer
 |Number of elements in the array
+
+|`min`
+|Array base type
+|Gets the minimam element of the array
+
+|`max`
+|Array base type
+|Gets the maximum element of the array
 |===
 
 ==== Streams

--- a/user_guide.adoc
+++ b/user_guide.adoc
@@ -2360,7 +2360,16 @@ library" for expression language.
 
 ==== Floating point numbers
 
-No methods are currently supported for floating point numbers.
+[cols="3*", options="header"]
+|===
+|Method name
+|Return type
+|Description
+
+|`to_i`
+|Integer
+|Truncates a floating point number to an integer
+|===
 
 ==== Byte arrays
 


### PR DESCRIPTION
Added methods of floating point numbers and arrays.

|method|implementation|spec|
|:-|:-|:-|
`to_s` of floating point number|https://github.com/kaitai-io/kaitai_struct_compiler/blob/154e2afe12d089b92bccb6a08c1bcc172e5b1f32/shared/src/main/scala/io/kaitai/struct/translators/CommonMethods.scala#L36-L39|https://github.com/kaitai-io/kaitai_struct_tests/blob/7c18ea47c34d199f19674077337a313db8cf2da5/formats/float_to_i.ksy#L20-L21|
|`min` of array|https://github.com/kaitai-io/kaitai_struct_compiler/blob/154e2afe12d089b92bccb6a08c1bcc172e5b1f32/shared/src/main/scala/io/kaitai/struct/translators/CommonMethods.scala#L45|https://github.com/kaitai-io/kaitai_struct_tests/blob/7c18ea47c34d199f19674077337a313db8cf2da5/formats/expr_array.ksy#L36-L37|
|`max` of array|https://github.com/kaitai-io/kaitai_struct_compiler/blob/154e2afe12d089b92bccb6a08c1bcc172e5b1f32/shared/src/main/scala/io/kaitai/struct/translators/CommonMethods.scala#L46|https://github.com/kaitai-io/kaitai_struct_tests/blob/7c18ea47c34d199f19674077337a313db8cf2da5/formats/expr_array.ksy#L38-L39|