### PR TITLE
Added line to disambiguate working directory for "Building for JVM".

### DIFF
--- a/developers.adoc
+++ b/developers.adoc
@@ -87,7 +87,8 @@ automatically as well.
 === Building for JVM
 
 We use http://www.scala-sbt.org/sbt-native-packager/[sbt-native-packager] to
-build deployable formats.
+build deployable formats. Note that in order to perform the following builds,
+one must be in the `kaitai_struct/compiler` directory.
 
 ==== Building an universal (.zip) package
 


### PR DESCRIPTION
Hi all,

As the team and I were looking at adding language support, we ran into a problem where we didn't realize we needed `kaitai-struct/compiler` as our working directory, instead of simply `kaitai_struct`. I just added a line in the documentation that I hope clarifies that for future users.

Thanks!