### PR TITLE
Parantheses in bit-sized integers are not correct

### DIFF
--- a/ksy_reference.adoc
+++ b/ksy_reference.adoc
@@ -680,8 +680,8 @@ For the sake of completeness, here's the full table of available integer types:
 ### Bit-size integers
 
 To specify integers having non-standard number of bits in them, one
-can use the following pattern: `b(\d+)`, where `\d+` is the number of
-bits allocated.
+can use the following pattern: `b(\d+)`, where `(\d+)` is the number of
+bits allocated. For example `b3` specifies a 3-bit integer.
 
 ### Floats
 


### PR DESCRIPTION
I propose to change the documentation so that its clear that the parantheses should be replaced. 
Additionally I added a small example.