### PR TITLE
Syntax highlighting: Replace CodeRay with Pygments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ cache:
   - apt
 
 before_install:
-  - gem install asciidoctor coderay
+  - gem install asciidoctor pygments.rb
+  - pip install Pygments
 
 script:
   - make

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,13 @@ TARGETS=\
 all: $(TARGETS)
 	rm -rf out/img
 	cp -r img styles js out
-	cp raw/coderay-asciidoctor.css out
+	cp raw/pygments-default.css out/styles
 
 out/%.html: raw/%.html tmpl/navbar.html postprocess-html
 	./postprocess-html $< $@
 
 raw/%.html: %.adoc styles/$(STYLESHEET).css raw/styles/$(STYLESHEET).css
-	TZ=UTC asciidoctor -a stylesheet=styles/$(STYLESHEET).css -a linkcss -D raw $<
+	TZ=UTC asciidoctor -a stylesheet=styles/$(STYLESHEET).css -a source-highlighter=pygments -a pygments-style=default -r ./pygments_init.rb -a linkcss -D raw $<
 
 raw/styles/$(STYLESHEET).css: styles/$(STYLESHEET).css
 	mkdir -p raw/styles

--- a/ci.adoc
+++ b/ci.adoc
@@ -1,7 +1,6 @@
 = Continuous Integration infrastructure
 Kaitai Project
 :toc: left
-:source-highlighter: coderay
 
 Kaitai Struct project sports a relatively complex CI (Continuous
 Integration) pipeline. This document describes how it's working.

--- a/developers.adoc
+++ b/developers.adoc
@@ -1,7 +1,6 @@
 = Developers memo
 Kaitai Project
 :toc: left
-:source-highlighter: coderay
 
 KS project consists of several subprojects, each of which has its own
 repository:

--- a/developers_intro.adoc
+++ b/developers_intro.adoc
@@ -2,7 +2,6 @@
 Kaitai Project
 v0.8
 :toc: left
-:source-highlighter: coderay
 :numbered:
 
 This document provides an overview of Kaitai Struct project from a

--- a/ksy_reference.adoc
+++ b/ksy_reference.adoc
@@ -1,7 +1,6 @@
 = Kaitai Struct: KSY reference
 :toc: left
 :toclevels: 3
-:source-highlighter: coderay
 
 Kaitai Struct is a DSL (domain-specific language), designed to
 describe binary data structures in human- and machine-readable

--- a/ksy_style_guide.adoc
+++ b/ksy_style_guide.adoc
@@ -2,7 +2,6 @@
 Kaitai Project
 v0.7
 :toc: left
-:source-highlighter: coderay
 :numbered:
 
 Although .ksy files are treated as YAML files, and YAML syntax allows

--- a/lang_cpp_stl.adoc
+++ b/lang_cpp_stl.adoc
@@ -1,5 +1,4 @@
 = Kaitai Struct: C++/STL notes
-:source-highlighter: coderay
 
 == Invocation
 

--- a/lang_java.adoc
+++ b/lang_java.adoc
@@ -1,6 +1,5 @@
 = Kaitai Struct: Java notes
 :toc: left
-:source-highlighter: coderay
 
 == Source files generation
 

--- a/lang_javascript.adoc
+++ b/lang_javascript.adoc
@@ -1,5 +1,4 @@
 = Kaitai Struct: JavaScript notes
-:source-highlighter: coderay
 
 == Quick start
 

--- a/lang_php.adoc
+++ b/lang_php.adoc
@@ -1,5 +1,4 @@
 = Kaitai Struct: PHP notes
-:source-highlighter: coderay
 
 The [Kaitai Struct: runtime for PHP](https://github.com/kaitai-io/kaitai_struct_php_runtime) requires PHP >= 7.0 and can be used in two different ways:
 

--- a/lang_python.adoc
+++ b/lang_python.adoc
@@ -2,7 +2,6 @@
 Kaitai Project
 v0.9
 :toc: left
-:source-highlighter: coderay
 
 [[overview]]
 == Overview

--- a/pygments_init.rb
+++ b/pygments_init.rb
@@ -1,0 +1,4 @@
+require 'pygments'
+
+# use a custom Pygments installation (directory that contains pygmentize)
+Pygments.start `dirname "$(which pygmentize)"`

--- a/pygments_init.rb
+++ b/pygments_init.rb
@@ -1,4 +1,4 @@
 require 'pygments'
 
 # use a custom Pygments installation (directory that contains pygmentize)
-Pygments.start `dirname "$(which pygmentize)"`
+Pygments.start `which pygmentize`

--- a/tmpl/header.html
+++ b/tmpl/header.html
@@ -1,3 +1,4 @@
 <link rel="stylesheet" href="styles/bootstrap.min.css">
 <link rel="stylesheet" href="styles/bootstrap-theme.min.css">
 <link rel="stylesheet" href="styles/main.css">
+<link rel="stylesheet" href="styles/pygments-default.css">

--- a/user_guide.adoc
+++ b/user_guide.adoc
@@ -2,7 +2,7 @@
 Kaitai Project
 v0.8
 :toc: left
-:source-highlighter: pygments
+:numbered:
 
 == Introduction
 

--- a/user_guide.adoc
+++ b/user_guide.adoc
@@ -2,8 +2,7 @@
 Kaitai Project
 v0.8
 :toc: left
-:source-highlighter: coderay
-:numbered:
+:source-highlighter: pygments
 
 == Introduction
 
@@ -2310,7 +2309,7 @@ inside strings literals. So, trying something like that would fail in
 some parsers (namely, it *will* fail using "desktop"
 kaitai-struct-compiler running under JVM):
 
-[source,java]
+[source,yaml]
 ----
 instances:
   foo:
@@ -2319,7 +2318,7 @@ instances:
 
 To ensure maximum compatibility, put quotes around such strings, i.e:
 
-[source,java]
+[source,yaml]
 ----
 instances:
   foo:


### PR DESCRIPTION
I suggest switching from [CodeRay](http://coderay.rubychan.de/) to [Pygments](https://pygments.org/). CodeRay doesn't support YAML much (for instance, see [this YAML test](http://coderay.rubychan.de/rays/7425) or [KSY sample](http://coderay.rubychan.de/rays/9274)) and doesn't really seem to be in active development. It supports only 22 languages (for example C#, Visual Basic, Swift, TypeScript, Perl, Kotlin, Rust, Scala and Haskell are missing).

[Pygments](https://pygments.org/) is a popular syntax highlighter. It supports almost 250 languages and a number of styles (here's a [online demo where you can play with it](https://pygments.org/demo/)). But the best thing is the support for [writing custom lexers](https://pygments.org/docs/lexerdevelopment/). This is the reason why I chose it: I would like to write a custom lexer for KSY, which would highlight the KS expression language as well. This is a prerequisite, but this change will immediately improve the readability of all code samples as well.

I installed the [pygments.rb gem](https://rubygems.org/gems/pygments.rb/) as suggested by the Asciidoctor docs and switched the `source-highlighter` to `pygments`. It worked, but the YAML highlighting was still somehow broken, while e.g. C code highlighting worked fine. I found that the pygments.rb is using some old version of Pygments, which had this issue: https://bitbucket.org/birkenfeld/pygments-main/pull-requests/762. So I install the latest Pygments with `pip install` and then created `pygments_init.rb`, which makes Asciidoctor to use the custom installation (see [Using a custom Pygments installation in Asciidoctor docs](https://asciidoctor.org/docs/user-manual/#using-a-custom-pygments-installation)).

If you don't like the `default` Pygments style, feel free to choose something nicer from https://pygments.org/demo/#style 🙂 