### PR TITLE
Preserve http(s) protocol when navigating to *.kaitai.io

### DIFF
--- a/ci.adoc
+++ b/ci.adoc
@@ -17,7 +17,7 @@ not to rely on a single CI engine provider. Currently, we use:
 
 With so many different jobs/flows, it's hard to rely on CI providers
 internal tools (such as job browsers, test browsers, log explorers,
-etc), so we're using our own https://ci.kaitai.io/[CI dashboard] to
+etc), so we're using our own link://ci.kaitai.io/[CI dashboard] to
 unify all the data coming from different test runs/sources and monitor
 current status of the compiler.
 
@@ -62,7 +62,7 @@ On a high level, it can be summarized as:
   https://github.com/kaitai-io/ci_artifacts/tree/ruby/1.9[ruby/1.9
   branch] keeps results of `ruby/1.9` test run.
 * Finally, these test results can be viewed online at our
-  https://ci.kaitai.io/[CI dashboard], which is a simple JavaScript
+  link://ci.kaitai.io/[CI dashboard], which is a simple JavaScript
   app which fetches and aggregates all test results from all runs on
   the fly.
 
@@ -104,7 +104,7 @@ possible.
    npm package]
 
 NOTE: Direct links / instructions how to reach these downloads are
-available as "unstable" at https://kaitai.io/[Kaitai homepage /
+available as "unstable" at link://kaitai.io/[Kaitai homepage /
 Download]
 
 * After compiler builds are finished, we run the internal compiler
@@ -158,7 +158,7 @@ TODO
 [[formats]]
 === Formats gallery
 
-https://formats.kaitai.io/[Formats gallery] is a static website, which
+link://formats.kaitai.io/[Formats gallery] is a static website, which
 provides user-friendly rendition of contents of our
 https://github.com/kaitai-io/kaitai_struct_formats/[formats repo].
 

--- a/ci.adoc
+++ b/ci.adoc
@@ -175,7 +175,7 @@ running on GitHub Actions]:
   ultimately, static website.
 * Static website gets published into
   https://github.com/kaitai-io/formats-kaitai-io.github.io[formats-kaitai-io.github.io
-  repo], which is served over HTTP to everyone as https://formats.kaitai.io/
+  repo], which is served over HTTP to everyone as link://formats.kaitai.io/[\http://formats.kaitai.io/]
 
 [[doc]]
 === Documentation

--- a/developers.adoc
+++ b/developers.adoc
@@ -249,6 +249,6 @@ After addition, don't forget to update lists of languages:
 * https://github.com/kaitai-io/kaitai_struct — project description
 * https://github.com/kaitai-io/kaitai_struct_compiler — project description
 * https://github.com/kaitai-io/kaitai_struct_compiler/blob/master/README.md — `-t` option documentation
-* https://kaitai.io — everywhere
+* link://kaitai.io[\http://kaitai.io] — everywhere
 * https://bintray.com/kaitai-io/debian/kaitai-struct-compiler/view — package description
 * https://twitter.com/kaitai_io — profile

--- a/developers.adoc
+++ b/developers.adoc
@@ -249,6 +249,6 @@ After addition, don't forget to update lists of languages:
 * https://github.com/kaitai-io/kaitai_struct — project description
 * https://github.com/kaitai-io/kaitai_struct_compiler — project description
 * https://github.com/kaitai-io/kaitai_struct_compiler/blob/master/README.md — `-t` option documentation
-* http://kaitai.io — everywhere
+* https://kaitai.io — everywhere
 * https://bintray.com/kaitai-io/debian/kaitai-struct-compiler/view — package description
 * https://twitter.com/kaitai_io — profile

--- a/dot/ci_overview.dot
+++ b/dot/ci_overview.dot
@@ -17,7 +17,7 @@ digraph {
 
 	build_compiler_appveyor [label="appveyor:\nbuild_compiler",fillcolor="#d0d0d0",href="https://ci.appveyor.com/project/GreyCat/kaitai-struct",target="_blank"];
 
-	dashboard [label="https://ci.kaitai.io/",href="https://ci.kaitai.io/",fillcolor="#ffb86c",target="_blank"];
+	dashboard [label="http://ci.kaitai.io/",href="//ci.kaitai.io/",fillcolor="#ffb86c",target="_blank"];
 	web_ide_unstable [label="https://ide.kaitai.io/devel/",href="https://ide.kaitai.io/devel/",fillcolor="#ffb86c",target="_blank"];
 
 	abridged_1 [label="...", style=none];

--- a/faq.adoc
+++ b/faq.adoc
@@ -131,9 +131,9 @@ for it.
 
 You can totally read an arbitrary binary format (or enjoy diverse
 library of ready-made format specifications, including
-https://formats.kaitai.io/gif/[.gif],
-https://formats.kaitai.io/wav/[.wav] and
-https://formats.kaitai.io/zip/[.zip]). To some extent, you can use KS
+link://formats.kaitai.io/gif/[.gif],
+link://formats.kaitai.io/wav/[.wav] and
+link://formats.kaitai.io/zip/[.zip]). To some extent, you can use KS
 in a task "send block of data from point A to point B", if you prefer
 to have more control over your serialization scheme — but, obviously,
 you'll have to add features like backwards compatibility, versioning,
@@ -149,7 +149,7 @@ mentioned protocols. It will typically give you many low-level
 implementation details, which you might care about if you're interested
 in digital forensics (DFIR) or digital preservation. You can find some
 of these protocols already specified under "Serialization Protocols"
-section in http://formats.kaitai.io/[Kaitai Struct Format Gallery].
+section in link://formats.kaitai.io/[Kaitai Struct Format Gallery].
 
 .Software mentioned
 ****
@@ -249,10 +249,10 @@ compiled right into parser source code in any supported language.
 In most cases, you can just import existing implementation from our
 stdlib:
 
-* http://formats.kaitai.io/vlq_base128_be/[vlq_base128_be] for
+* link://formats.kaitai.io/vlq_base128_be/[vlq_base128_be] for
   big-endian VLQ (as used in ASN.1 BER encoding, standard MIDI file
   format, etc)
-* http://formats.kaitai.io/vlq_base128_le/[vlq_base128_le] for
+* link://formats.kaitai.io/vlq_base128_le/[vlq_base128_le] for
   little-endian VLQ (as used in DWARF debugging info, Google Protocol
   Buffers, Apache Lucene, Apache Avro, etc)
 
@@ -281,7 +281,7 @@ There's lot of variety when it comes to BCD representations:
 * Endianness: might be little or big
 
 Kaitai Struct stdlibs include a parameterized type
-http://formats.kaitai.io/bcd/[bcd] which supports majority of these BCD
+link://formats.kaitai.io/bcd/[bcd] which supports majority of these BCD
 versions using parameters (available in Kaitai Struct v0.8+):
 
 * `num_digits` — integer, number of digits (valid values: 1..8)

--- a/index.adoc
+++ b/index.adoc
@@ -34,7 +34,7 @@
 
 == Want to contribute to KS development?
 
-* https://ci.kaitai.io/[CI (Continuous Integration) dashboard]
+* link://ci.kaitai.io/[CI (Continuous Integration) dashboard]
 * <<developers.adoc#,Developers memo>> — basic information on how to build, test and release KS
 * <<developers_intro.adoc#,Developers intro>> — gentle introduction to KS reference compiler architecture
 * <<new_language.adoc#,Adding support for new target language>>

--- a/lang_javascript.adoc
+++ b/lang_javascript.adoc
@@ -10,7 +10,7 @@ Create an empty directory and install the https://www.npmjs.com/package/kaitai-s
 npm i kaitai-struct
 ```
 
-Copy your compiled .ksy parser into this directory or download one http://formats.kaitai.io/[parser from the format gallery] (eg. http://formats.kaitai.io/elf/javascript.html[Elf.js]).
+Copy your compiled .ksy parser into this directory or download one link://formats.kaitai.io/[parser from the format gallery] (eg. link://formats.kaitai.io/elf/javascript.html[Elf.js]).
 
 Create `index.js` with the following content:
 
@@ -57,7 +57,7 @@ Create an `index.html` with the following content:
 </html>
 ```
 
-Copy your compiled .ksy parser into this directory or download one http://formats.kaitai.io/[parser from the format gallery] (eg. http://formats.kaitai.io/elf/javascript.html[Elf.js]).
+Copy your compiled .ksy parser into this directory or download one link://formats.kaitai.io/[parser from the format gallery] (eg. link://formats.kaitai.io/elf/javascript.html[Elf.js]).
 
 Also deploy the Kaitai Struct JavaScript Runtime (`KaitaiStream.js`)  https://github.com/koczkatamas/kaitai_struct_javascript_runtime/blob/master/KaitaiStream.js[from Github] or https://www.npmjs.com/package/kaitai-struct[npm] and a `sample.elf` file.
 

--- a/lang_php.adoc
+++ b/lang_php.adoc
@@ -15,7 +15,7 @@ mkdir kaitai-test
 cd kaitai-test
 
 #######################################################################################
-# Download Kaitai Struct Compiler, link can be found at http://kaitai.io/#download page
+# Download Kaitai Struct Compiler, link can be found at https://kaitai.io/#download page
 
 curl -OL https://bintray.com/artifact/download/kaitai-io/universal/0.6/kaitai-struct-compiler-0.6.zip
 

--- a/new_language.adoc
+++ b/new_language.adoc
@@ -16,7 +16,7 @@ Things to check out and familiarize oneself with:
 * enums
 * processing algorithms
 
-Clone https://github.com/kaitai-io/kaitai_struct/[central KS repo], learn <<developers.adoc#,how to build a compiler from sources>>, install prerequisites, try to build the compiler and run the tests. Take a look at our https://ci.kaitai.io/[CI].
+Clone https://github.com/kaitai-io/kaitai_struct/[central KS repo], learn <<developers.adoc#,how to build a compiler from sources>>, install prerequisites, try to build the compiler and run the tests. Take a look at our link://ci.kaitai.io/[CI].
 
 == Plan how to map KS concept to concepts of new target language
 

--- a/user_guide.adoc
+++ b/user_guide.adoc
@@ -1255,8 +1255,8 @@ not parsed due to alignment.
 IMPORTANT: Feature available since v0.9.
 
 Most formats using little-endian _byte order_ with packed multi-byte
-bit fields (e.g. http://formats.kaitai.io/android_img/[android_img],
-http://formats.kaitai.io/rar/[rar] or http://formats.kaitai.io/swf/[swf])
+bit fields (e.g. link://formats.kaitai.io/android_img/[android_img],
+link://formats.kaitai.io/rar/[rar] or link://formats.kaitai.io/swf/[swf])
 assume that such bit fields are unpacked manually using bitwise operators
 from a little-endian integer parsed in advance containing the whole bit
 field. The bit layout of the field is designed accordingly.

--- a/user_guide.adoc
+++ b/user_guide.adoc
@@ -54,7 +54,7 @@ course, Kaitai Struct offers that as well.
 
 ==== Installation
 
-Please refer to http://kaitai.io/#download[official website] for
+Please refer to link://kaitai.io/#download[official website] for
 installation instructions. After installation, you're expected to
 have:
 
@@ -3468,16 +3468,16 @@ to a crash / segfault / security problem.
 
 IMPORTANT: Feature available since v0.8.
 
-Most formats (like http://formats.kaitai.io/zip/[zip],
-http://formats.kaitai.io/gif/[gif], and many others) stick to a single
+Most formats (like link://formats.kaitai.io/zip/[zip],
+link://formats.kaitai.io/gif/[gif], and many others) stick to a single
 fixed endianness: they always use either big-endian or little-endian
 integers. Usually it stems from the architecture where the format was
 developed: this way format is relatively easy and quick to parse on
 its "native" architecture, and requires some extra operations (and
 parsing time) on non-native architectures.
 
-Some formats (like http://formats.kaitai.io/elf/[ELF] or
-http://formats.kaitai.io/mach_o/[Mach-O]), however, take alternative
+Some formats (like link://formats.kaitai.io/elf/[ELF] or
+link://formats.kaitai.io/mach_o/[Mach-O]), however, take alternative
 approach: they come in two versions (with big-endian integers and
 little-endian integers) and they add some sort of header field that
 helps to distinguish between two.


### PR DESCRIPTION
In response to https://github.com/kaitai-io/kaitai_struct_doc/pull/43#discussion_r495605159

Note: `link:` is the syntax for [_link macro_](https://asciidoctor.org/docs/asciidoc-writers-guide/#external-links) in AsciiDoc, it is **not** a special protocol. When you use one of the auto-recognized protocols (`http:` or `https:`), the `link:` macro is not necessary (so instead of `link:https://en.wikipedia.org/[Wikipedia]`, you can write just `https://en.wikipedia.org/[Wikipedia]`), but "no protocol" (`//...`) is not recognized this way, so it has to be done like `link://kaitai.io[Homepage]`.

Cc @dgelessus 