### PR TITLE
developers.adoc: Add simple development loop overview

### DIFF
--- a/developers.adoc
+++ b/developers.adoc
@@ -58,13 +58,16 @@ The general process of making and testing a change once you have the
 prerequistes and sources ready:
 
 * Making changes in the `compiler` repo:
-  * Perform a "stage build" with SBT: `sbt compilerJVM/stage`
-  * Use your new compiler directly: `./jvm/target/universal/stage/bin/kaitai-struct-compiler <args>`
-* Running tests:
-  * Run tests from the `tests` repo
-  * Build the compiler if needed: `./build-compiler <lang>` (`lang` may be something like `cpp_stl_11`)
-  * Regenerate compiled outputs: `./build-formats`
-  * Compile (if needed) and run the tests: `./run-<lang>`
+** Perform a "stage build" with SBT: `sbt compilerJVM/stage`
+** Use your new compiler directly: `./jvm/target/universal/stage/bin/kaitai-struct-compiler <args>`
+*** Adding `./jvm/target/universal/stage/bin/` to your `PATH` is helpful here
+* Tests are run from the `tests` repo. After building the compiler:
+** When needed (e.g. you added a test), build new tests with <<kst.adoc#_invoking_kst_translator,KST translator>>:
+*** `./spec_kst_to_all [-f <test_name>] [-t lang]`
+** If `.ksy` files changed, regenerate compiled outputs:
+*** `./build-formats`
+** Compile (if needed) and run the tests
+*** `./run-<lang>`
 
 === Prerequisites
 

--- a/developers.adoc
+++ b/developers.adoc
@@ -52,6 +52,20 @@ several ways:
 ** not packaged, used as a source JS file on a website
 ** packaged as https://www.npmjs.com/[npm] package
 
+=== Development loop
+
+The general process of making and testing a change once you have the
+prerequistes and sources ready:
+
+* Making changes in the `compiler` repo:
+  * Perform a "stage build" with SBT: `sbt compilerJVM/stage`
+  * Use your new compiler directly: `./jvm/target/universal/stage/bin/kaitai-struct-compiler <args>`
+* Running tests:
+  * Run tests from the `tests` repo
+  * Build the compiler if needed: `./build-compiler <lang>` (`lang` may be something like `cpp_stl_11`)
+  * Regenerate compiled outputs: `./build-formats`
+  * Compile (if needed) and run the tests: `./run-<lang>`
+
 === Prerequisites
 
 To build the compiler, one generally needs just these two things:


### PR DESCRIPTION
This is just the minimal expected workflow for how you can build and test changes.

----

As someone unfamiliar with both Scala (i.e. how do you drive this SBT thing?) and the Kaitai struct repo structure, I found it quite hard to figure out what the expected "development loop" is (i.e. what you basically need to do to "write come code, see if it works, adjust the code, see if it works"). I patched them together based on what seemed to work, of course let me know if I am doing it wrong!

These instructions don't actually currently work without patching, as the tests are broken by the Julia stuff as mentioned in https://github.com/kaitai-io/kaitai_struct/issues/1127.